### PR TITLE
in_tail: Fix memory leak in docker_mode_parser

### DIFF
--- a/plugins/in_tail/tail_dockermode.c
+++ b/plugins/in_tail/tail_dockermode.c
@@ -254,6 +254,7 @@ int flb_tail_dmode_process_content(time_t now,
         if (ctx->docker_mode_parser) {
             ret = flb_parser_do(ctx->docker_mode_parser, line, line_len,
                                 &out_buf, &out_size, &out_time);
+            flb_free(out_buf);
 
             /*
             * Buffered log should be flushed out


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
